### PR TITLE
Bump peaceiris/actions-gh-pages from v2 to v3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,7 @@ jobs:
           format: html
           output: ./gh-pages/index.html
       - run: "find ./gh-pages"
-      - uses: peaceiris/actions-gh-pages@v2
-        env:
-          ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          PUBLISH_DIR: gh-pages
-          PUBLISH_BRANCH: gh-pages
+      - uses: peaceiris/actions-gh-pages@v3.6.4
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          publish_dir: gh-pages


### PR DESCRIPTION
Version 2 is no longer be maintained.

The latest README: https://github.com/peaceiris/actions-gh-pages