### PR TITLE
Remove alum status for Francesco Renzi

### DIFF
--- a/humans.txt.yaml
+++ b/humans.txt.yaml
@@ -68,7 +68,6 @@ humans:
 - name: "Florian Wagner"
   alum: true
 - name: "Francesco Renzi"
-  alum: true
 - name: "Guðmundur Bjarni Ólafsson"
   alum: true
 - name: "Hayden Faulds"


### PR DESCRIPTION
Removed 'alum: true' for Francesco Renzi.